### PR TITLE
Fix url link for code tables in geonames schemas

### DIFF
--- a/cloud-formation/python/geolocator-lambda.py
+++ b/cloud-formation/python/geolocator-lambda.py
@@ -31,13 +31,14 @@ def lambda_handler(event, context):
     schemas = geolocator.get_schemas()
     # Extract IO schemas
     in_api_schema = schemas.get(IN_API)
-    out_api_schema = schemas.get(OUT_API)
-    output_schema = out_api_schema.get("definitions").get("output")
-    schema_items = output_schema.get("items").get("properties")
-    schema_required = output_schema.get("items").get("required")
+    output_schema_items = schemas.get(OUT_API). \
+                            get("definitions"). \
+                            get("output"). \
+                            get("items")
     # 0. Read and Validate the parameters
     params_full_list = validate_querystring_against_schema(event,in_api_schema)
     keys = params_full_list.pop("keys")
+    lang = params_full_list.get("lang")
     # services to call
     for service_id in keys:
         model = schemas.get(service_id)
@@ -45,13 +46,12 @@ def lambda_handler(event, context):
         # Adjust the parameters to the service's schema
         url, params = assemble_url(schema, params_full_list.copy())
         # At this point the query must be complete
-        service_load= url_request(url, params)
+        service_load = url_request(url, params)
         # At this point is where the 'out' part of each model applies
         items = items_from_service(service_id,
+                                   lang,
                                    model,
-                                   schema_items,
-                                   schema_required,
+                                   output_schema_items,
                                    service_load)
         loads.extend(items)
-
     return loads

--- a/cloud-formation/python/geolocator.py
+++ b/cloud-formation/python/geolocator.py
@@ -1,11 +1,10 @@
 import json
 import s3_manager
 import botocore
-import urllib.request
 from constants import *
 from url_methods import url_request
 
-class Schema:
+class Schema():
     """
     Defines the schema object for each service
 
@@ -19,12 +18,14 @@ class Schema:
     _schema = ""
     _tables = {}
 
+    # Init
     def __init__(self, schema_json):
         """
         Create the instance of this object
         """
         self._schema = schema_json
 
+    # Methods
     def get_schema(self):
         """
         Return this instance of the object
@@ -38,26 +39,33 @@ class Schema:
         The tables are kept permanently in memory as attributes of each instance
         """
         schema_url_tables=self._schema.get("urlCodeTables")
-        for key in schema_url_tables:
-            table_content={}
-            schema_define_table = schema_url_tables.get(key)
-            url_table = schema_define_table.get("url")
-            table_schema = url_request(url_table, {})
-            if schema_define_table.get("type")=="array":
-                name_container=schema_define_table.get("name")
-                items = table_schema.get(name_container)
-                schema_fields=schema_define_table.get("fields")
-                schema_code=schema_fields.get("code")
-                schema_field=schema_fields.get("description")
-                for item in items:
-                    code=item.get(schema_code)
-                    value=item.get(schema_field)
-                    table_content[code]=value
-            self._tables[key]=table_content
+        if schema_url_tables:
+            for lang in [ "en", "fr" ]:
+                _lang_tables = {}
+                for key in schema_url_tables:
+                    table_content={}
+                    schema_define_table = schema_url_tables.get(key)
+                    url_table= schema_define_table.get("url")
+                    url_lang_table = url_table.replace("_PARAM1_", lang)
+                    ### This is just a temorary bypass ###
+                    if (lang=="fr") and (key=="generic"):
+                        url_lang_table = url_table.replace("_PARAM1_", "en")
+                    ######################################
+                    table_schema = url_request(url_lang_table, {})
+                    if schema_define_table.get("type")=="array":
+                        name_container=schema_define_table.get("name")
+                        items = table_schema.get(name_container)
+                        schema_fields=schema_define_table.get("fields")
+                        schema_code=schema_fields.get("code")
+                        schema_field=schema_fields.get("description")
+                        for item in items:
+                            code=item.get(schema_code)
+                            value=item.get(schema_field)
+                            table_content[code]=value
+                    _lang_tables[key]=table_content
+                self._tables[lang] = _lang_tables
 
-        return self._tables
-
-    def get_from_table(self, field, item):
+    def get_from_table(self, field, lang, code):
         """
         Identifies the table and record to get the value from
 
@@ -70,14 +78,12 @@ class Schema:
         return The value asociated to the code in this table
         """
         fields=field.split(".")
+        # table name
         table_name=fields[0]
-        data_field=item.get(table_name)
-        column_name=fields[1]
-        code=data_field.get(column_name)
-        return self._tables.get(table_name).get(code)
+        return self._tables.get(lang).get(table_name).get(code)
 
 # Singleton Class
-class Geolocator(object):
+class Geolocator():
     """
     Create one single instance to read and keep in memory the schemas for
     input/output as well as all the services available

--- a/cloud-formation/python/params_manager.py
+++ b/cloud-formation/python/params_manager.py
@@ -62,7 +62,7 @@ def validate_param_with_schema(param, schema):
             param = param.split(",")
         items = schema.get("items")
         enum = items.get("enum")
-        invalid = [item_param for item_param in param if item_param not in enum]
+        invalid = [item_prm for item_prm in param if item_prm not in enum]
         if len(invalid) > 0:
             error_message = f"invalid parameter value(s) '{invalid}'"
             raise Exception(error_message)

--- a/cloud-formation/python/url_methods.py
+++ b/cloud-formation/python/url_methods.py
@@ -1,6 +1,5 @@
 import json
 import requests
-import urllib.request
 import asyncio
 
 def get_from_field(field, item):
@@ -82,7 +81,7 @@ def assemble_url(schema, params):
              service schema.
     """
     # 1. Extract url and parameters from json
-    url = schema.get("url")[:-1]
+    url = schema.get("url")
     url_params = schema.get("urlParams")
     # 2. Parameters to modify the url
     if url_params:
@@ -90,7 +89,6 @@ def assemble_url(schema, params):
     # 3. lookup in parameters to replace with
     qry_params_dict = params
     lookup_in = schema.get("lookup").get("in")
-    qry_params_list = []
     if lookup_in:
         for in_param in lookup_in:
             qry_params_dict[lookup_in.get(in_param)] = params.pop(in_param)

--- a/schemas/services/geonames-schema.json
+++ b/schemas/services/geonames-schema.json
@@ -6,7 +6,7 @@
     "staticParams": {},
     "urlCodeTables": {
         "province" : {
-            "url": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+            "url": "https://geogratis.gc.ca/services/geoname/_PARAM1_/codes/province.json",
             "type": "array",
             "name": "definitions",
             "fields": {
@@ -15,7 +15,7 @@
             }
         },
         "generic": {
-            "url": "https://geogratis.gc.ca/services/geoname/en/codes/generic.json",
+            "url": "https://geogratis.gc.ca/services/geoname/_PARAM1_/codes/generic.json",
             "type": "array",
             "name": "definitions",
             "fields": {


### PR DESCRIPTION
The _geonames-schema_'s urls for code tables: **province** and **generic** are now generalized and the resource for the language must be replaced in run time.

Note. having now two sets of tables to be read in memory, it increments the latency of the first reading of this information into the geolocator object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview-api-geolocator/64)
<!-- Reviewable:end -->
