### PR TITLE
78 province names

### DIFF
--- a/schemas/services/locate-schema.json
+++ b/schemas/services/locate-schema.json
@@ -40,7 +40,10 @@
                 },
                 "province": {
                     "field": "component.province",
-                    "lookup": ""
+                    "lookup": {
+                        "type": "table",
+                        "field": "description"
+                    }
                 },
                 "tag": [
                     {

--- a/schemas/services/nominatim-schema.json
+++ b/schemas/services/nominatim-schema.json
@@ -59,8 +59,11 @@
                 }
             ],
             "province": {
-                "field": "",
-                "lookup": ""
+                "field": "display_name",
+                "lookup": {
+                    "type": "csv",
+                    "field":"3"
+                }
             },
             "tag": {
                     "field": "class",

--- a/schemas/tables/component.csv
+++ b/schemas/tables/component.csv
@@ -1,0 +1,16 @@
+Code,en,fr
+NL,Newfoundland and Labrador,Terre-Neuve-et-Labrador
+PE,Prince Edward Island,Île-du-Prince-Édouard
+NS,Nova Scotia,Nouvelle-Écosse
+NB,New Brunswick,Nouveau-Brunswick
+QC,Quebec,Québec
+ON,Ontario,Ontario
+MB,Manitoba,Manitoba
+SK,Saskatchewan,Saskatchewan
+AB,Alberta,Alberta
+BC,British Columbia,Colombie-Britannique
+YU,Yukon,Yukon
+YT,Yukon,Yukon
+NT,Northwest Territories,Territoires du Nord-Ouest
+NU,Nunavut,Nunavut
+CA,,


### PR DESCRIPTION
Issue #78 normalize province names.  Locate shows full province name from province abbreviation.  Nominatim shows province name extracted from display_name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview-api-geolocator/79)
<!-- Reviewable:end -->
