### PR TITLE
80 locate key tags

### DIFF
--- a/backend/api-lambda/model_manager.py
+++ b/backend/api-lambda/model_manager.py
@@ -46,6 +46,11 @@ def get_from_table(table_params, field, item):
     tables, lang, table_update = table_params
     code = get_from_schema(field, item)
     table_name = field.split('.')[0]
+    field_name = field.split('.')[1]
+    # component.generic use generic lookup table
+    if table_name == 'component' and field_name == 'generic':
+        table_name = 'generic'
+
     if code in tables.get(table_name):
        return tables.get(table_name).get(code).get(lang)
 

--- a/schemas/services/locate-schema.json
+++ b/schemas/services/locate-schema.json
@@ -51,8 +51,11 @@
                         "lookup": ""
                     },
                     {
-                        "field": "component.concise",
-                        "lookup": ""
+                        "field": "component.generic",
+                        "lookup": {
+                            "type": "table",
+                            "field": "term"
+                        }
                     }
                 ]
             }

--- a/schemas/tables/component.csv
+++ b/schemas/tables/component.csv
@@ -1,5 +1,5 @@
 Code,en,fr
-NL,Newfoundland and Labrador,Terre-Neuve-et-Labrador
+NL,Newfoundland and Labrador,Terre-Neuve et Labrador
 PE,Prince Edward Island,Île-du-Prince-Édouard
 NS,Nova Scotia,Nouvelle-Écosse
 NB,New Brunswick,Nouveau-Brunswick


### PR DESCRIPTION
issue #80 Data Normalization - location tags.  Locate key tags now use the generic lookup table (from geonames).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview-api-geolocator/81)
<!-- Reviewable:end -->
